### PR TITLE
scribblec: Fix help text for modelpng

### DIFF
--- a/scribble-dist/src/main/resources/scribblec.sh
+++ b/scribble-dist/src/main/resources/scribblec.sh
@@ -70,7 +70,7 @@ Options:
 
 
   -model <simple global protocol name>          Generate global model
-  -modelpng <simple global protocol name> <role> <output file>
+  -modelpng <simple global protocol name> <output file>
           Draw global model as png (requires dot)
   -fair                                         Assume fair output choices
   -umodel, -umodelpng (with appropriate args)   "Unfair" variant


### PR DESCRIPTION
Summary:
In
https://github.com/scribble/scribble-java/blob/19ea1dc1dfd5d08378e31a63c51a8d6a54d10f7a/scribble-cli/src/main/java/org/scribble/cli/CLArgParser.java#L244
the argument parser invokes
https://github.com/scribble/scribble-java/blob/19ea1dc1dfd5d08378e31a63c51a8d6a54d10f7a/scribble-cli/src/main/java/org/scribble/cli/CLArgParser.java#L376
which requires a protocol and a file.

The help says a protocol, a role and a file is expected, this is
incorrect.