### PR TITLE
Enforce iteration ordering for Protocols

### DIFF
--- a/scribble-ast/src/main/java/org/scribble/job/Job.java
+++ b/scribble-ast/src/main/java/org/scribble/job/Job.java
@@ -137,7 +137,7 @@ public class Job
 		if (this.core == null)
 		{
 			Map<ModuleName, Module> parsed = this.context.getParsed();
-			Set<GProtocol> imeds = new HashSet<>();
+			Set<GProtocol> imeds = new LinkedHashSet<>();
 			for (ModuleName fullname : parsed.keySet())
 			{
 				GTypeTranslator t = this.config.vf.GTypeTranslator(this, fullname,

--- a/scribble-core/src/main/java/org/scribble/core/job/CoreContext.java
+++ b/scribble-core/src/main/java/org/scribble/core/job/CoreContext.java
@@ -15,6 +15,7 @@ package org.scribble.core.job;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -86,8 +87,9 @@ public class CoreContext
 	{
 		this.core = core;
 		//this.modcs = Collections.unmodifiableMap(modcs);
-		this.imeds = imeds.stream()
-				.collect(Collectors.toMap(x -> x.fullname, x -> x));
+		Map<ProtoName<Global>, GProtocol> tmp = new LinkedHashMap<>();
+		imeds.stream().forEach(x -> tmp.put(x.fullname, x));
+		this.imeds = tmp;
 	}
 	
 	// Used by Core for pass running


### PR DESCRIPTION
This provides a more consistent state number ordering by fixiating the
iterator order.